### PR TITLE
fix: temporarily disable routes in AFFunctionGenqlSelection

### DIFF
--- a/src/clients/functions.ts
+++ b/src/clients/functions.ts
@@ -59,7 +59,8 @@ export class FunctionsClient {
     slug: true,
     invokeUrl: true,
     projectId: true,
-    routes: true,
+    // TODO: Re-enable when @alternatefutures/utils-genql-client v0.5.0 is published
+    // routes: true,
     currentDeploymentId: true,
     currentDeployment: {
       cid: true,


### PR DESCRIPTION
## Summary
- Temporarily comments out `routes: true` in `AFFunction_MAPPED_PROPERTIES`
- This unblocks TypeDoc generation for the documentation site deployment

## Problem
The `routes` property is not available in `@alternatefutures/utils-genql-client` versions 0.2.0-0.4.0, causing TypeScript compilation errors during documentation generation:

```
src/clients/functions.ts:56:5 - error TS2353: Object literal may only specify known properties, and 'routes' does not exist in type 'AFFunctionGenqlSelection'
```

## Solution
Comment out the `routes` property with a TODO to re-enable when `@alternatefutures/utils-genql-client` v0.5.0 is published with the updated schema.

## Test Plan
- [ ] TypeScript compilation passes
- [ ] TypeDoc generation succeeds
- [ ] web-docs.alternatefutures.ai deployment workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)